### PR TITLE
To make the CLI run globally use config json file to get api key instead of dotenv 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules/
 .env
+config.json

--- a/IMDb.js
+++ b/IMDb.js
@@ -3,7 +3,7 @@ const tab = require('table-master');
 const chalk = require('chalk');
 const figlet = require('figlet');
 const axios = require('axios');
-require('dotenv').config()
+const config = require('./config')
 
 /**
  * Class to  handle scraping of IMDb
@@ -92,7 +92,7 @@ exports.IMDb = class {
    * @returns {String}
    */
   getAPIKey() {
-    return process.env.API_KEY;
+    return config.apikey;
   }
 
   /**

--- a/readme.md
+++ b/readme.md
@@ -6,10 +6,12 @@ This is a repo for a Node-CLI that Searches IMDb for and it's primary purpose is
 
 The IMDB-CLI needs an api key from OMDb to work properly. You can easily get your own API key from the site.
 
-Once you have your api key you need to create a `.env` file in the project root folder with the following content:
+Once you have your api key you need to create a `config.json` file in the project root folder with the following content:
 
-```
-API_KEY='YOUR-API-KEY'
+```json
+{
+  "apikey": "YOUR-API-KEY"
+}
 ```
 
 ## Usage


### PR DESCRIPTION
This PR contains a bugfix for running the cli globally, i.e not from the project folder. When running globally the dotenv config was not read properly and the endpoints resulted in 401's due to missing api keys.

To fix this (until dotenv and globally running the cli works) a workaround is to use a config.json file instead