### PR TITLE
Add option through program args to set truncation size

### DIFF
--- a/IMDb.js
+++ b/IMDb.js
@@ -17,7 +17,7 @@ exports.IMDb = class {
    * @param {string} query - search query that has been sanitized
    * @param {string} originalQuery - The original search query
    */
-  constructor({ query, originalQuery, showPlot = false, searchByType = null }) {
+  constructor({ query, originalQuery, showPlot = false, searchByType = null, limitPlot = 40 }) {
     this.query = query;
     this.originalQuery = originalQuery;
     this.url = `http://www.imdb.com/search/title?title=${this.query}`;
@@ -25,6 +25,7 @@ exports.IMDb = class {
     this.outputColor = chalk.hex('#f3ce13');
     this.showPlot = showPlot;
     this.searchByType = searchByType;
+    this.limitPlot = parseInt(limitPlot, 10);
   }
 
   /**
@@ -112,8 +113,8 @@ exports.IMDb = class {
    * @param {String} text string to truncate
    * @param {Integer} [limit=40] Limit truncation to a specific amount of chars
    */
-  getTruncatedText({ text, limit = 40 }) {
-    return `${text.substring(0, limit)}...`;
+  getTruncatedText({ text }) {
+    return `${text.substring(0, this.limitPlot)}...`;
   }
 
   /**

--- a/index.js
+++ b/index.js
@@ -9,7 +9,7 @@ const pkg = require('./package');
 const inputError = 'Please enter a query to search for...';
 
 program
-  .version(pkg.version)
+  .version(pkg.version, '-v --version')
   .option('-p, --plot', 'Show plot in search result')
   .option(
     '-t, --title [title]',

--- a/index.js
+++ b/index.js
@@ -12,6 +12,10 @@ program
   .version(pkg.version, '-v --version')
   .option('-p, --plot', 'Show plot in search result')
   .option(
+    '-l, --limit-plot [number]',
+    'Limit the amount of characters to be displayed for plot text. If omitted a default amount will be used'
+  )
+  .option(
     '-t, --title [title]',
     'Search by a specific title. If omitted the program will prompt you for a title to search for'
   )
@@ -46,6 +50,7 @@ if (program.title) {
     query: query.getSanitizedQuery(),
     originalquery: program.title,
     showPlot: !!program.plot,
+    limitPlot: program.limitPlot,
     searchByType: IMDb.determineType({ movies: program.movies, series: program.series })
   });
   imdbInstance.search();
@@ -57,6 +62,7 @@ if (program.title) {
       query: query.getSanitizedQuery(),
       originalquery: answer.searchString,
       showPlot: !!program.plot,
+      limitPlot: program.limitPlot,
       searchByType: IMDb.determineType({ movies: program.movies, series: program.series })
     });
     imdbInstance.search();


### PR DESCRIPTION
This PR adds the flag `-l --limit-plot` to set the truncation size of plots displayed in the search result. 

* Pass` -l --limit-plot` to set truncation size
* Made argument for displaying cli version lowercase