### PR TITLE
Implementation of sorting of search result by either year or title

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5183,9 +5183,9 @@
       }
     },
     "lodash": {
-      "version": "4.17.4",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
-      "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4="
+      "version": "4.17.11",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
+      "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg=="
     },
     "lodash.sortby": {
       "version": "4.7.0",

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "dotenv": "^8.0.0",
     "figlet": "^1.2.0",
     "inquirer": "^3.2.2",
+    "lodash": "^4.17.11",
     "ora": "^1.3.0",
     "table-master": "^1.0.3"
   },

--- a/src/index.js
+++ b/src/index.js
@@ -20,6 +20,7 @@ program
   )
   .option('-m, --movies', 'Search by movies only. Cannot be used alongside "series" parameter')
   .option('-s --series', 'Search by series only. Cannot be used alongside "movie" parameter')
+  .option('-o, --order-by [column]', 'Sort the search result by a column')
   .parse(process.argv);
 
 if (program.movies && program.series) {
@@ -48,6 +49,7 @@ if (program.title) {
     query: program.title,
     showPlot: !!program.plot,
     limitPlot: program.limitPlot,
+    sortColumn: program.orderBy,
     searchByType: IMDb.determineType({ movies: program.movies, series: program.series })
   });
   imdbInstance.search();
@@ -58,6 +60,7 @@ if (program.title) {
       query: answer.searchString,
       showPlot: !!program.plot,
       limitPlot: program.limitPlot,
+      sortColumn: program.orderBy,
       searchByType: IMDb.determineType({ movies: program.movies, series: program.series })
     });
     imdbInstance.search();

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,3 +1,5 @@
+const orderBy = require('lodash/orderBy');
+
 /**
  * Encode a string as a URI component
  * @param {String} query to encode
@@ -5,4 +7,15 @@
  */
 const sanitizeQuery = query => encodeURIComponent(query);
 
+/**
+ * Get a sorted array of objects sorted by object key value and by asc or desc order
+ * @param {Array} items
+ * @param {String} column
+ * @param {String} order asc or desc
+ */
+const sortByColumn = ({ items, column, order }) => {
+  return orderBy(items, [column], [order]);
+};
+
 exports.sanitizeQuery = sanitizeQuery;
+exports.sortByColumn = sortByColumn;

--- a/src/utils.test.js
+++ b/src/utils.test.js
@@ -1,7 +1,7 @@
-const { sanitizeQuery } = require('./utils');
+const { sanitizeQuery, sortByColumn } = require('./utils');
 
 describe('Utils functions', () => {
-  describe('sanitizeQuery', () => {
+  describe('sanitizeQuery()', () => {
     it('should be defined', () => {
       expect(sanitizeQuery).toBeDefined();
     });
@@ -12,6 +12,18 @@ describe('Utils functions', () => {
     it('should not sanitize if not needed', () => {
       const query = 'Interstellar';
       expect(sanitizeQuery(query)).toMatch(query);
+    });
+  });
+  describe('sortColumn()', () => {
+    it('should be defined', () => {
+      expect(sortByColumn).toBeDefined();
+    });
+    it('should sort array of columns', () => {
+      const items = [{ title: 'b', year: 3 }, { title: 'a', year: 2 }, { title: 'c', year: 1 }];
+      const sortedByTitle = sortByColumn({ items, column: 'title', order: 'asc' });
+      const sortedByYear = sortByColumn({ items, column: 'year', order: 'desc' });
+      expect(sortedByTitle[0].title).toMatch('a');
+      expect(sortedByYear[0].year === 3).toBeTruthy();
     });
   });
 });


### PR DESCRIPTION
This PR adds the possibility to sort the search result, either by year or title. Sorting will for now be done ascending for titles and ascending for years

* `-o --order-by` accepts either title or year for sorting
* Sorting is done with lodash `orderBy()` method