### PR TITLE
Cleanup and more usage of enums/interfaces

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,4 +1,5 @@
 module.exports = {
+  setupFiles: ["<rootDir>/jest.setup.js"],
   roots: ['<rootDir>/src'],
   transform: {
     '^.+\\.tsx?$': 'ts-jest'

--- a/jest.setup.js
+++ b/jest.setup.js
@@ -1,0 +1,1 @@
+require('dotenv').config({ path: './.env'});

--- a/src/IMDb.test.ts
+++ b/src/IMDb.test.ts
@@ -1,5 +1,5 @@
 import IMDb from './IMDb';
-import { SearchResult } from './types/searchResult';
+import { SearchResult, SearchResultType } from './types/searchResult';
 
 const queryObj = {
   query: 'harry potter',
@@ -18,16 +18,16 @@ describe('IMDb class', () => {
 
   it('should default to not search by any type or show plot', () => {
     expect(imdbInstance.showPlot).toBe(false);
-    expect(imdbInstance.searchByType).toBe('');
+    expect(imdbInstance.searchByType).toBe(SearchResultType.All);
   });
 
   describe('determineType()', () => {
     it('should return the right type', () => {
-      expect(IMDb.determineType({ movies: true })).toMatch('movie');
-      expect(IMDb.determineType({ series: true })).toMatch('series');
-      expect(IMDb.determineType({ series: false })).toBe(null);
-      expect(IMDb.determineType({ movies: false })).toBe(null);
-      expect(IMDb.determineType({})).toBe(null);
+      expect(IMDb.determineType({ movies: true })).toMatch(SearchResultType.Movies);
+      expect(IMDb.determineType({ series: true })).toMatch(SearchResultType.Series);
+      expect(IMDb.determineType({ series: false })).toBe(SearchResultType.All);
+      expect(IMDb.determineType({ movies: false })).toBe(SearchResultType.All);
+      expect(IMDb.determineType({})).toBe(SearchResultType.All);
     });
   });
 
@@ -46,7 +46,7 @@ describe('IMDb class', () => {
     it('should to able to get only movies', async () => {
       const imdbInstanceHP = new IMDb({
         query: 'star wars',
-        searchByType: 'movie',
+        searchByType: SearchResultType.Movies,
       });
       const { data } = await imdbInstanceHP.getSearchResult(imdbInstanceHP.query);
       const filteredData = data.Search.filter((item: SearchResult) => {
@@ -58,7 +58,7 @@ describe('IMDb class', () => {
     it('should to able to get only series', async () => {
       const imdbInstanceSW = new IMDb({
         query: 'star wars',
-        searchByType: 'series',
+        searchByType: SearchResultType.Series,
       });
       const { data } = await imdbInstanceSW.getSearchResult(imdbInstanceSW.query);
       const filteredData = data.Search.filter((item: SearchResult) => item.Type === 'series');

--- a/src/IMDb.test.ts
+++ b/src/IMDb.test.ts
@@ -1,5 +1,5 @@
 import IMDb from './IMDb';
-import { ISearchResult } from './interfaces';
+import { SearchResult } from './types/searchResult';
 
 const queryObj = {
   query: 'harry potter',
@@ -49,7 +49,9 @@ describe('IMDb class', () => {
         searchByType: 'movie',
       });
       const { data } = await imdbInstanceHP.getSearchResult(imdbInstanceHP.query);
-      const filteredData = data.Search.filter((item: ISearchResult) => item.Type === 'movie');
+      const filteredData = data.Search.filter((item: SearchResult) => {
+        return item.Type === 'movie';
+      });
       expect(filteredData.length).toBeGreaterThan(0);
     });
 
@@ -59,7 +61,7 @@ describe('IMDb class', () => {
         searchByType: 'series',
       });
       const { data } = await imdbInstanceSW.getSearchResult(imdbInstanceSW.query);
-      const filteredData = data.Search.filter((item: ISearchResult) => item.Type === 'series');
+      const filteredData = data.Search.filter((item: SearchResult) => item.Type === 'series');
       expect(filteredData.length).toBeGreaterThan(0);
     });
   });

--- a/src/IMDb.ts
+++ b/src/IMDb.ts
@@ -9,7 +9,7 @@ const { sanitizeQuery, sortByColumn } = require('./utils');
 
 import { MovieOrSeries, SortObject } from './types';
 import { IMDbProperties } from './types/imdb';
-import { FormattedSearchResult, SearchResult } from './types/searchResult';
+import { FormattedSearchResult, SearchResult, SearchResultType } from './types/searchResult';
 
 /**
  * Class to  handle scraping of IMDb
@@ -34,21 +34,21 @@ class IMDb implements IMDbProperties {
    * @param {Boolean} series
    * @returns {String}
    */
-  public static determineType({ movies, series }: MovieOrSeries) {
+  public static determineType({ movies, series }: {[key: string]: boolean} ): SearchResultType {
     if (movies) {
-      return 'movie';
+      return SearchResultType.Movies;
     }
     if (series) {
-      return 'series';
+      return SearchResultType.Series;
     }
-    return null;
+    return SearchResultType.All;
   }
   public query: string;
   public originalQuery: string;
   public results: FormattedSearchResult[];
   public outputColor: (text: string) => string;
   public showPlot: boolean;
-  public searchByType: any;
+  public searchByType: SearchResultType;
   public limitPlot: number;
   public sortColumn: any;
   public baseUrl: string;
@@ -60,7 +60,7 @@ class IMDb implements IMDbProperties {
    * @param {integer} [limitPlot=40] Amount to limit plot to before it truncates
    * @param {string} [sortColumn=null] Specify a column to sort by. Supports 'title' or 'year'
    */
-  constructor({ query = '', showPlot = false, searchByType = '', limitPlot = 40, sortColumn = '' }) {
+  constructor({ query = '', showPlot = false, searchByType = SearchResultType.All, limitPlot = 40, sortColumn = '' }) {
     this.query = sanitizeQuery(query);
     this.originalQuery = query;
     this.results = [];
@@ -129,10 +129,10 @@ class IMDb implements IMDbProperties {
    * @returns {Promise}
    */
   public getSearchResult(query: string): Promise<any> {
-    if (this.searchByType) {
-      return axios.get(`${this.baseUrl}&s=${query}&type=${this.searchByType}`);
+    if (this.searchByType === SearchResultType.All) {
+      return axios.get(`${this.baseUrl}&s=${query}`);
     }
-    return axios.get(`${this.baseUrl}&s=${query}`);
+    return axios.get(`${this.baseUrl}&s=${query}&type=${this.searchByType}`);
   }
 
   public getItemByIMDbId(imdbId: string): Promise<any> {

--- a/src/IMDb.ts
+++ b/src/IMDb.ts
@@ -7,7 +7,7 @@ const axios = require('axios');
 const capitalze = require('lodash/capitalize');
 const { sanitizeQuery, sortByColumn } = require('./utils');
 
-import { IFormattedSearchResult, IMDbProperties, IMovieOrSeries, ISearchResult, ISortObject } from './interfaces';
+import { FormattedSearchResult, IMDbProperties, MovieOrSeries, SearchResult, SortObject } from './types';
 
 /**
  * Class to  handle scraping of IMDb
@@ -32,7 +32,7 @@ class IMDb implements IMDbProperties {
    * @param {Boolean} series
    * @returns {String}
    */
-  public static determineType({ movies, series }: IMovieOrSeries) {
+  public static determineType({ movies, series }: MovieOrSeries) {
     if (movies) {
       return 'movie';
     }
@@ -43,7 +43,7 @@ class IMDb implements IMDbProperties {
   }
   public query: string;
   public originalQuery: string;
-  public results: IFormattedSearchResult[];
+  public results: FormattedSearchResult[];
   public outputColor: (text: string) => string;
   public showPlot: boolean;
   public searchByType: any;
@@ -97,7 +97,7 @@ class IMDb implements IMDbProperties {
   /**
    * Get a sorted array of the search result
    */
-  public getSortedSearchResult(): ISortObject {
+  public getSortedSearchResult(): SortObject {
     return sortByColumn({
       items: this.results,
       column: this.sortColumn,
@@ -153,10 +153,10 @@ class IMDb implements IMDbProperties {
    * Get a formatted search result to display from ISearchResult data
    * @param {Object} input
    * @param {Boolean} includePlot Determine if plot should be included in the formatted result
-   * @returns {IFormattedSearchResult}
+   * @returns {FormattedSearchResult}
    */
-  public getFormattedSearchResult(input: ISearchResult, includePlot: boolean = false): IFormattedSearchResult {
-    const result: IFormattedSearchResult = {
+  public getFormattedSearchResult(input: SearchResult, includePlot: boolean = false): FormattedSearchResult {
+    const result: FormattedSearchResult = {
       'Title': input.Title,
       'Year': input.Year,
       'Type': input.Type,
@@ -187,13 +187,13 @@ class IMDb implements IMDbProperties {
         const promises = await Promise.all(fullPromises);
         const results = promises.map((result: any) => result.data);
         const searchResult = results.map(
-          (result: ISearchResult) => this.getFormattedSearchResult(result, this.showPlot),
+          (result: SearchResult) => this.getFormattedSearchResult(result, this.showPlot),
         );
         this.createSearchResult(searchResult);
         spinner.stop();
         this.renderSearchResults();
       } else {
-        const searchResult = data.Search.map((result: ISearchResult) => this.getFormattedSearchResult(result));
+        const searchResult = data.Search.map((result: SearchResult) => this.getFormattedSearchResult(result));
         this.createSearchResult(searchResult);
         spinner.stop();
         this.renderSearchResults();

--- a/src/IMDb.ts
+++ b/src/IMDb.ts
@@ -114,9 +114,6 @@ class IMDb implements IMDbProperties {
     const orderToSortBy = this.sortColumn === SearchResultSortColumn.Year ?
     SearchResultSortOrder.Descending
     : SearchResultSortOrder.Ascending;
-    console.log('order to sort by', orderToSortBy);
-    console.log('column to sort by', this.sortColumn);
-
     return sortByColumn({
       items: this.results,
       column: SortOrder[this.sortColumn],

--- a/src/IMDb.ts
+++ b/src/IMDb.ts
@@ -7,7 +7,7 @@ const axios = require('axios');
 const capitalze = require('lodash/capitalize');
 const { sanitizeQuery, sortByColumn } = require('./utils');
 
-import { MovieOrSeries, SortObject } from './types';
+import { SortObject } from './types';
 import { IMDbProperties } from './types/imdb';
 import { FormattedSearchResult, SearchResult, SearchResultType } from './types/searchResult';
 

--- a/src/IMDb.ts
+++ b/src/IMDb.ts
@@ -4,7 +4,6 @@ const tab = require('table-master');
 const chalk = require('chalk');
 const figlet = require('figlet');
 const axios = require('axios');
-const capitalze = require('lodash/capitalize');
 const { sanitizeQuery, sortByColumn } = require('./utils');
 
 import { IMDbProperties } from './types/imdb';

--- a/src/IMDb.ts
+++ b/src/IMDb.ts
@@ -7,7 +7,9 @@ const axios = require('axios');
 const capitalze = require('lodash/capitalize');
 const { sanitizeQuery, sortByColumn } = require('./utils');
 
-import { FormattedSearchResult, IMDbProperties, MovieOrSeries, SearchResult, SortObject } from './types';
+import { MovieOrSeries, SortObject } from './types';
+import { IMDbProperties } from './types/imdb';
+import { FormattedSearchResult, SearchResult } from './types/searchResult';
 
 /**
  * Class to  handle scraping of IMDb

--- a/src/IMDb.ts
+++ b/src/IMDb.ts
@@ -7,7 +7,6 @@ const axios = require('axios');
 const capitalze = require('lodash/capitalize');
 const { sanitizeQuery, sortByColumn } = require('./utils');
 
-import { SortObject } from './types';
 import { IMDbProperties } from './types/imdb';
 import {
   FormattedSearchResult,
@@ -15,6 +14,7 @@ import {
   SearchResultSortColumn,
   SearchResultSortOrder,
   SearchResultType,
+  SortObject,
   SortOrder,
 } from './types/searchResult';
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,8 +1,8 @@
-import { FormattedSearchResult } from './types/searchResult';
+import { FormattedSearchResult, SearchResultSortColumn, SearchResultSortOrder } from './types/searchResult';
 
 export interface SortObject {
   items: FormattedSearchResult[];
-  column: string;
-  order: any;
+  column: SearchResultSortColumn;
+  order: SearchResultSortOrder;
 }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,8 +1,0 @@
-import { FormattedSearchResult, SearchResultSortColumn, SearchResultSortOrder } from './types/searchResult';
-
-export interface SortObject {
-  items: FormattedSearchResult[];
-  column: SearchResultSortColumn;
-  order: SearchResultSortOrder;
-}
-

--- a/src/types.ts
+++ b/src/types.ts
@@ -5,7 +5,3 @@ export interface SortObject {
   order: any;
 }
 
-export interface MovieOrSeries {
-  movies?: boolean;
-  series?: boolean;
-}

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,6 +1,7 @@
+import { FormattedSearchResult } from './types/searchResult';
 
 export interface SortObject {
-  items: any[];
+  items: FormattedSearchResult[];
   column: string;
   order: any;
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,35 +1,8 @@
-export interface IMDbProperties {
-  query: string;
-  originalQuery: string;
-  baseUrl: string;
-  results: FormattedSearchResult[];
-  outputColor: (text: string) => string;
-  showPlot: boolean;
-  searchByType: string;
-  limitPlot: number;
-  sortColumn?: string;
-}
 
 export interface SortObject {
   items: any[];
   column: string;
   order: any;
-}
-
-export interface SearchResult {
-  Title: string;
-  Year: string;
-  Type: string;
-  Plot?: string;
-  imdbID: string;
-}
-
-export interface FormattedSearchResult {
-  Title: string;
-  Year: string;
-  Type: string;
-  Plot?: string;
-  'IMDb ID': string;
 }
 
 export interface MovieOrSeries {

--- a/src/types.ts
+++ b/src/types.ts
@@ -2,7 +2,7 @@ export interface IMDbProperties {
   query: string;
   originalQuery: string;
   baseUrl: string;
-  results: IFormattedSearchResult[];
+  results: FormattedSearchResult[];
   outputColor: (text: string) => string;
   showPlot: boolean;
   searchByType: string;
@@ -10,13 +10,13 @@ export interface IMDbProperties {
   sortColumn?: string;
 }
 
-export interface ISortObject {
+export interface SortObject {
   items: any[];
   column: string;
   order: any;
 }
 
-export interface ISearchResult {
+export interface SearchResult {
   Title: string;
   Year: string;
   Type: string;
@@ -24,7 +24,7 @@ export interface ISearchResult {
   imdbID: string;
 }
 
-export interface IFormattedSearchResult {
+export interface FormattedSearchResult {
   Title: string;
   Year: string;
   Type: string;
@@ -32,7 +32,7 @@ export interface IFormattedSearchResult {
   'IMDb ID': string;
 }
 
-export interface IMovieOrSeries {
+export interface MovieOrSeries {
   movies?: boolean;
   series?: boolean;
 }

--- a/src/types/imdb.ts
+++ b/src/types/imdb.ts
@@ -1,0 +1,13 @@
+import { FormattedSearchResult } from './searchResult';
+
+export interface IMDbProperties {
+  query: string;
+  originalQuery: string;
+  baseUrl: string;
+  results: FormattedSearchResult[];
+  outputColor: (text: string) => string;
+  showPlot: boolean;
+  searchByType: string;
+  limitPlot: number;
+  sortColumn?: string;
+}

--- a/src/types/searchResult.ts
+++ b/src/types/searchResult.ts
@@ -31,9 +31,14 @@ export enum SearchResultSortOrder {
   Descending = 'desc',
  }
 
+export interface SortObject {
+  items: FormattedSearchResult[];
+  column: string;
+  order: SearchResultSortOrder;
+}
+
 export const SortOrder = {
    [SearchResultSortColumn.Title]: 'Title',
    [SearchResultSortColumn.Year]: 'Year',
    [SearchResultSortColumn.None]: 'None',
-
  };

--- a/src/types/searchResult.ts
+++ b/src/types/searchResult.ts
@@ -1,0 +1,15 @@
+export interface SearchResult {
+  Title: string;
+  Year: string;
+  Type: string;
+  Plot?: string;
+  imdbID: string;
+}
+
+export interface FormattedSearchResult {
+  Title: string;
+  Year: string;
+  Type: string;
+  Plot?: string;
+  'IMDb ID': string;
+}

--- a/src/types/searchResult.ts
+++ b/src/types/searchResult.ts
@@ -19,3 +19,21 @@ export enum SearchResultType {
   Series = 'series',
   All =  'all',
 }
+
+export enum SearchResultSortColumn {
+ Title = 'title',
+ Year = 'year',
+ None = 'none',
+}
+
+export enum SearchResultSortOrder {
+  Ascending = 'asc',
+  Descending = 'desc',
+ }
+
+export const SortOrder = {
+   [SearchResultSortColumn.Title]: 'Title',
+   [SearchResultSortColumn.Year]: 'Year',
+   [SearchResultSortColumn.None]: 'None',
+
+ };

--- a/src/types/searchResult.ts
+++ b/src/types/searchResult.ts
@@ -13,3 +13,9 @@ export interface FormattedSearchResult {
   Plot?: string;
   'IMDb ID': string;
 }
+
+export enum SearchResultType {
+  Movies = 'movie',
+  Series = 'series',
+  All =  'all',
+}

--- a/src/utils.test.ts
+++ b/src/utils.test.ts
@@ -1,3 +1,4 @@
+import { SearchResultSortColumn, SearchResultSortOrder, SearchResultType, SortOrder } from './types/searchResult';
 import { sanitizeQuery, sortByColumn } from './utils';
 
 describe('Utils functions', () => {
@@ -19,11 +20,23 @@ describe('Utils functions', () => {
       expect(sortByColumn).toBeDefined();
     });
     it('should sort array of columns', () => {
-      const items = [{ title: 'b', year: 3 }, { title: 'a', year: 2 }, { title: 'c', year: 1 }];
-      const sortedByTitle = sortByColumn({ items, column: 'title', order: 'asc' });
-      const sortedByYear = sortByColumn({ items, column: 'year', order: 'desc' });
-      expect(sortedByTitle[0].title).toMatch('a');
-      expect(sortedByYear[0].year === 3).toBeTruthy();
+      const items = [
+        { 'Title': 'a', 'Year': '2', 'Type': SearchResultType.Movies, 'IMDb ID': '2' },
+        { 'Title': 'b', 'Year': '3', 'Type': SearchResultType.Movies, 'IMDb ID': '1' },
+        { 'Title': 'c', 'Year': '1', 'Type': SearchResultType.Movies, 'IMDb ID': '3' },
+      ];
+      const sortedByTitle = sortByColumn({
+        items,
+        column: SortOrder[SearchResultSortColumn.Title],
+        order: SearchResultSortOrder.Ascending,
+      });
+      const sortedByYear = sortByColumn({
+        items,
+        column: SortOrder[SearchResultSortColumn.Year],
+        order: SearchResultSortOrder.Descending,
+      });
+      expect(sortedByTitle[0].Title).toMatch('a');
+      expect(sortedByYear[0].Year === '3').toBeTruthy();
     });
   });
 });

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,6 +1,6 @@
 import orderBy from 'lodash/orderBy';
 
-import { ISortObject } from './interfaces';
+import { SortObject } from './types';
 
 /**
  * Encode a string as a URI component
@@ -15,4 +15,4 @@ export const sanitizeQuery = (query: string) => encodeURIComponent(query);
  * @param {String} column
  * @param {String} order asc or desc
  */
-export const sortByColumn = ({ items, column, order }: ISortObject) => orderBy(items, [column], [order]);
+export const sortByColumn = ({ items, column, order }: SortObject) => orderBy(items, [column], [order]);

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,6 +1,5 @@
 import orderBy from 'lodash/orderBy';
-
-import { SortObject } from './types';
+import { SortObject } from './types/searchResult';
 
 /**
  * Encode a string as a URI component

--- a/tslint.json
+++ b/tslint.json
@@ -10,6 +10,7 @@
             true,
             "single"
         ],
+        "interface-name": false,
         "object-literal-sort-keys": false,
         "no-var-requires": false
     },


### PR DESCRIPTION
This PR clean ups the usage of interfaces by doing the following:
* Split upp interfaces and move into a types folder
* Remove tslint rule to capitalize interfaces with "I"
* Determine sort order and sort column with enums
* Determine search result type with enum
* Some interfaces got revamped to utilize other interfaces and not rely on 'any' for laziness


Also:
* Use jest setup-file to load env variables