### PR TITLE
Improve rendering of search results

### DIFF
--- a/src/IMDb.test.ts
+++ b/src/IMDb.test.ts
@@ -100,14 +100,4 @@ describe('IMDb class', () => {
       'Title,Year,Type,Plot,IMDb ID'.split(',').map((objKey: string) => expect(objFormatted).toHaveProperty(objKey));
     });
   });
-
-  describe('createSearchResult()', () => {
-    it('should add search results from a given array', () => {
-      const results = [{ Title: 'a' }, { Title: 'b' }];
-      expect(imdbInstance.results.length).toBe(0);
-      imdbInstance.createSearchResult(results);
-      expect(imdbInstance.results.length).toBe(results.length);
-      expect(imdbInstance.results[0].Title).toMatch(results[0].Title);
-    });
-  });
 });

--- a/src/IMDb.ts
+++ b/src/IMDb.ts
@@ -116,7 +116,7 @@ class IMDb implements IMDbProperties {
    * Get available values to sort by
    * @returns {Array}
    */
-  get availableColumnsToSort(): string[] {
+  get availableColumnsToSort(): SearchResultSortColumn[] {
     return [SearchResultSortColumn.Year, SearchResultSortColumn.Title];
   }
 

--- a/src/IMDb.ts
+++ b/src/IMDb.ts
@@ -51,7 +51,6 @@ class IMDb implements IMDbProperties {
     return SearchResultType.All;
   }
   public query: string;
-  public originalQuery: string;
   public outputColor: (text: string) => string;
   public showPlot: boolean;
   public searchByType: SearchResultType;
@@ -72,8 +71,7 @@ class IMDb implements IMDbProperties {
     limitPlot = 40,
     sortColumn = SearchResultSortColumn.None,
   }) {
-    this.query = sanitizeQuery(query);
-    this.originalQuery = query;
+    this.query = query;
     this.outputColor = chalk.hex('#f3ce13');
     this.showPlot = showPlot;
     this.searchByType = searchByType;
@@ -87,7 +85,7 @@ class IMDb implements IMDbProperties {
    */
   public renderSearchResults(result?: FormattedItem[]): void {
     if (!result) {
-      console.log(chalk.red(`\nCould not find any search results for '${this.originalQuery}'. Please try again.`));
+      console.log(chalk.red(`\nCould not find any search results for '${this.query}'. Please try again.`));
       return;
     }
     if (this.availableColumnsToSort.includes(this.sortColumn)) {
@@ -121,15 +119,17 @@ class IMDb implements IMDbProperties {
   }
 
   /**
-   * Get search result promise by query
+   * Get search result promise by query.
+   * Method will sanitize the input query
    * @param {String} query
    * @returns {Promise}
    */
   public async getSearchResult(query: string): Promise<Item[]> {
+    const sanitizedQuery = sanitizeQuery(query);
     if (this.searchByType === SearchResultType.All) {
-      return searchByQuery(query);
+      return searchByQuery(sanitizedQuery);
     }
-    return searchByQueryAndType(query, this.searchByType);
+    return searchByQueryAndType(sanitizedQuery, this.searchByType);
   }
 
   /**

--- a/src/types/imdb.ts
+++ b/src/types/imdb.ts
@@ -1,6 +1,5 @@
 export interface IMDbProperties {
   query: string;
-  originalQuery: string;
   outputColor: (text: string) => string;
   showPlot: boolean;
   searchByType: string;

--- a/src/types/imdb.ts
+++ b/src/types/imdb.ts
@@ -1,9 +1,6 @@
-import { FormattedItem } from './searchResult';
-
 export interface IMDbProperties {
   query: string;
   originalQuery: string;
-  results: FormattedItem[];
   outputColor: (text: string) => string;
   showPlot: boolean;
   searchByType: string;


### PR DESCRIPTION
This PR improves upon the flow of rendering search result by doing:
* There is no more a method to create search result that exist as an array of imdb instance
* `search()` methods performs API calls and passed the response to `renderSearchResult()` which now take the response as a parameter - and not rely on the search result existing on the imdb instance
* Available columns to sort by is now a getter and not a method
* **Bonus** original query is removed. Imdb class now stores only the query (non-encoded) and the method to search, `getSearchResult` will sanitize the passed query parameter. 