### PR TITLE
Add omdb api functions to get entire series

### DIFF
--- a/src/omdbApi.test.ts
+++ b/src/omdbApi.test.ts
@@ -1,34 +1,47 @@
-import { getItemById, getItemsByIds, getSeasonFromTitle, searchByQuery, searchByQueryAndType } from './omdbApi';
-import { SearchResultType } from './types/searchResult';
-import { sanitizeQuery } from './utils';
+  import * as omdbApi from './omdbApi';
+  import { SearchResultType } from './types/searchResult';
+  import { sanitizeQuery } from './utils';
 
-describe('OMDb API Functions', () => {
+  describe('OMDb API Functions', () => {
   describe('searchByQuery()', () => {
     it('should get search result for a given query', async () => {
-      const items = await searchByQuery(sanitizeQuery('Harry potter'));
+      const items = await omdbApi.searchByQuery(sanitizeQuery('Harry potter'));
       expect(items.length).toBeGreaterThan(1);
     });
   });
   describe('searchByQueryAndType()', async () => {
     it('should get search result for a given query and type', async () => {
-      const items = await searchByQueryAndType(sanitizeQuery('Star wars'), SearchResultType.Series);
+      const items = await omdbApi.searchByQueryAndType(sanitizeQuery('Star wars'), SearchResultType.Series);
       items.map((item) => expect(item.Type).toEqual(SearchResultType.Series));
     });
   });
   describe('getItemById()', async () => {
     it('should get a given item for a imdb id', async () => {
       const id = 'tt1201607';
-      const item = await getItemById(id);
+      const item = await omdbApi.getItemById(id);
       expect(item.imdbID).toEqual(id);
     });
   });
   describe('getItemsByIds()', async () => {
     it('should get a given items for imdb ids', async () => {
       const ids = ['tt1201607', 'tt0241527'];
-      const items = await getItemsByIds(ids);
+      const items = await omdbApi.getItemsByIds(ids);
       const resultItds = items.map((item) => item.imdbID);
       resultItds.map((id) => expect(ids.includes(id)).toEqual(true));
     });
   });
-
+  describe('getSeasonFromTitle', () => {
+    it('should get a specific season for a given title', async () => {
+      const title = sanitizeQuery('Game of thrones');
+      const season = await omdbApi.getSeasonFromTitle(title, 1);
+      expect(season.Season).toEqual('1');
+    });
+  });
+  describe('getSeasonFromId', () => {
+    it('should get a specific season for a given imdb id', async () => {
+      const id = 'tt0944947';
+      const season = await omdbApi.getSeasonFromId(id, 1);
+      expect(season.Season).toEqual('1');
+    });
+  });
 });

--- a/src/omdbApi.test.ts
+++ b/src/omdbApi.test.ts
@@ -30,18 +30,36 @@
       resultItds.map((id) => expect(ids.includes(id)).toEqual(true));
     });
   });
-  describe('getSeasonFromTitle', () => {
+  describe('getSeasonFromTitle()', () => {
     it('should get a specific season for a given title', async () => {
       const title = sanitizeQuery('Game of thrones');
       const season = await omdbApi.getSeasonFromTitle(title, 1);
-      expect(season.Season).toEqual('1');
+      expect(season.seasonNumber).toEqual('1');
     });
   });
-  describe('getSeasonFromId', () => {
+  describe('getSeasonFromId()', () => {
     it('should get a specific season for a given imdb id', async () => {
       const id = 'tt0944947';
       const season = await omdbApi.getSeasonFromId(id, 1);
-      expect(season.Season).toEqual('1');
+      expect(season.seasonNumber).toEqual('1');
+    });
+  });
+  describe('getAllSeasonsFromId()', () => {
+    it('should get full series for a given imdb id', async () => {
+      const id = 'tt0944947';
+      const series = await omdbApi.getFullSeriesFromId(id);
+      expect(series.title).toBeDefined();
+      expect(series.totalSeasons).toBeDefined();
+      expect(series.seasons.length).toBeGreaterThan(0);
+    });
+  });
+  describe('getAllSeasonsFromTitle()', () => {
+    it('should get full series for a given title', async () => {
+      const title = sanitizeQuery('game of thrones');
+      const series = await omdbApi.getFullSeriesFromTitle(title);
+      expect(series.title).toBe('Game of Thrones');
+      expect(series.totalSeasons).toBeDefined();
+      expect(series.seasons.length).toBeGreaterThan(0);
     });
   });
 });

--- a/src/omdbApi.test.ts
+++ b/src/omdbApi.test.ts
@@ -1,0 +1,34 @@
+import { getItemById, getItemsByIds, getSeasonFromTitle, searchByQuery, searchByQueryAndType } from './omdbApi';
+import { SearchResultType } from './types/searchResult';
+import { sanitizeQuery } from './utils';
+
+describe('OMDb API Functions', () => {
+  describe('searchByQuery()', () => {
+    it('should get search result for a given query', async () => {
+      const items = await searchByQuery(sanitizeQuery('Harry potter'));
+      expect(items.length).toBeGreaterThan(1);
+    });
+  });
+  describe('searchByQueryAndType()', async () => {
+    it('should get search result for a given query and type', async () => {
+      const items = await searchByQueryAndType(sanitizeQuery('Star wars'), SearchResultType.Series);
+      items.map((item) => expect(item.Type).toEqual(SearchResultType.Series));
+    });
+  });
+  describe('getItemById()', async () => {
+    it('should get a given item for a imdb id', async () => {
+      const id = 'tt1201607';
+      const item = await getItemById(id);
+      expect(item.imdbID).toEqual(id);
+    });
+  });
+  describe('getItemsByIds()', async () => {
+    it('should get a given items for imdb ids', async () => {
+      const ids = ['tt1201607', 'tt0241527'];
+      const items = await getItemsByIds(ids);
+      const resultItds = items.map((item) => item.imdbID);
+      resultItds.map((id) => expect(ids.includes(id)).toEqual(true));
+    });
+  });
+
+});

--- a/src/omdbApi.test.ts
+++ b/src/omdbApi.test.ts
@@ -9,20 +9,20 @@
       expect(items.length).toBeGreaterThan(1);
     });
   });
-  describe('searchByQueryAndType()', async () => {
+  describe('searchByQueryAndType()', () => {
     it('should get search result for a given query and type', async () => {
       const items = await omdbApi.searchByQueryAndType(sanitizeQuery('Star wars'), SearchResultType.Series);
       items.map((item) => expect(item.Type).toEqual(SearchResultType.Series));
     });
   });
-  describe('getItemById()', async () => {
+  describe('getItemById()', () => {
     it('should get a given item for a imdb id', async () => {
       const id = 'tt1201607';
       const item = await omdbApi.getItemById(id);
       expect(item.imdbID).toEqual(id);
     });
   });
-  describe('getItemsByIds()', async () => {
+  describe('getItemsByIds()', () => {
     it('should get a given items for imdb ids', async () => {
       const ids = ['tt1201607', 'tt0241527'];
       const items = await omdbApi.getItemsByIds(ids);

--- a/src/omdbApi.ts
+++ b/src/omdbApi.ts
@@ -1,5 +1,6 @@
 const axios = require('axios');
-import { FullItem, FullSeries, Item, SearchResultType, Season } from './types/searchResult';
+import { FullItem, Item, SearchResultType } from './types/searchResult';
+import { Season, Series } from './types/series';
 
 const API_KEY = process.env.API_KEY;
 const BASE_URL = `http://www.omdbapi.com?apikey=${API_KEY}`;
@@ -56,7 +57,7 @@ export const getFullSeriesFromId = async (id: string) => {
       title,
       totalSeasons,
       seasons,
-    } as FullSeries;
+    } as Series;
 };
 
 export const getFullSeriesFromTitle = async (title: string) => {
@@ -71,5 +72,5 @@ export const getFullSeriesFromTitle = async (title: string) => {
     title: seriesTitle,
     totalSeasons,
     seasons,
-  } as FullSeries;
+  } as Series;
 };

--- a/src/omdbApi.ts
+++ b/src/omdbApi.ts
@@ -1,5 +1,5 @@
 const axios = require('axios');
-import {FullItem, Item, SearchResultType} from './types/searchResult';
+import { FullItem, Item, SearchResultType, Season } from './types/searchResult';
 
 const API_KEY = process.env.API_KEY;
 const BASE_URL = `http://www.omdbapi.com?apikey=${API_KEY}`;
@@ -23,3 +23,12 @@ export const getItemsByIds = async (ids: string[]): Promise<FullItem[]> => {
   const items = await Promise.all(ids.map((id: string) => getItemById(id)));
   return items as FullItem[];
 };
+
+export const getSeasonFromTitle = async (title: string, season: number) => {
+  const { data } = await axios.get(`${BASE_URL}&t=${title}&Season=${season}`);
+  return data as Season;
+};
+
+export const getSeasonFromId = async (id: string, season: number) => {
+  const { data } = await axios.get(`${BASE_URL}&i=${id}&Season=${season}&Episode=1`);
+  return data as Season; };

--- a/src/omdbApi.ts
+++ b/src/omdbApi.ts
@@ -30,6 +30,6 @@ export const getSeasonFromTitle = async (title: string, season: number) => {
 };
 
 export const getSeasonFromId = async (id: string, season: number) => {
-  const { data } = await axios.get(`${BASE_URL}&i=${id}&Season=${season}&Episode=1`);
+  const { data } = await axios.get(`${BASE_URL}&i=${id}&Season=${season}`);
   return data as Season;
 };

--- a/src/omdbApi.ts
+++ b/src/omdbApi.ts
@@ -31,4 +31,5 @@ export const getSeasonFromTitle = async (title: string, season: number) => {
 
 export const getSeasonFromId = async (id: string, season: number) => {
   const { data } = await axios.get(`${BASE_URL}&i=${id}&Season=${season}&Episode=1`);
-  return data as Season; };
+  return data as Season;
+};

--- a/src/types/searchResult.ts
+++ b/src/types/searchResult.ts
@@ -33,22 +33,27 @@ export interface FullItem extends Item {
 export interface Episode {
   Title: string;
   Released: string;
-  Episide: string;
+  Episode: string;
   imdbRating: string;
   imdbId: string;
 }
 
 export interface Season {
- Title: string;
- Season: string;
+ title: string;
+ seasonNumber: string;
  totalSeasons: string;
- Episodes: Episode[];
- Response: string;
+ episodes: Episode[];
 }
 
 export interface Rating {
   Source: string;
   Value: string;
+}
+
+export interface FullSeries {
+  title: string;
+  totalSeasons: string;
+  seasons: Season[];
 }
 
 export interface FormattedItem {

--- a/src/types/searchResult.ts
+++ b/src/types/searchResult.ts
@@ -30,6 +30,22 @@ export interface FullItem extends Item {
   Response: string;
 }
 
+export interface Episode {
+  Title: string;
+  Released: string;
+  Episide: string;
+  imdbRating: string;
+  imdbId: string;
+}
+
+export interface Season {
+ Title: string;
+ Season: string;
+ totalSeasons: string;
+ Episodes: Episode[];
+ Response: string;
+}
+
 export interface Rating {
   Source: string;
   Value: string;

--- a/src/types/searchResult.ts
+++ b/src/types/searchResult.ts
@@ -30,30 +30,9 @@ export interface FullItem extends Item {
   Response: string;
 }
 
-export interface Episode {
-  Title: string;
-  Released: string;
-  Episode: string;
-  imdbRating: string;
-  imdbId: string;
-}
-
-export interface Season {
- title: string;
- seasonNumber: string;
- totalSeasons: string;
- episodes: Episode[];
-}
-
 export interface Rating {
   Source: string;
   Value: string;
-}
-
-export interface FullSeries {
-  title: string;
-  totalSeasons: string;
-  seasons: Season[];
 }
 
 export interface FormattedItem {

--- a/src/types/series.ts
+++ b/src/types/series.ts
@@ -1,0 +1,20 @@
+export interface Season {
+  title: string;
+  seasonNumber: string;
+  totalSeasons: string;
+  episodes: Episode[];
+ }
+
+export interface Episode {
+  Title: string;
+  Released: string;
+  Episode: string;
+  imdbRating: string;
+  imdbId: string;
+}
+
+export interface Series {
+  title: string;
+  totalSeasons: string;
+  seasons: Season[];
+}


### PR DESCRIPTION
This PR includes functionality to get entire series or seasons of a series through the omdb api. This will be useful to display info about a series where the scores of episodes could be used to give insights to how well a series is doing over time.
* New api functions to get entire series/seasons
* Added tests for all omdb api functions