### PR TITLE
Search series to display their average season scores

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -24,6 +24,9 @@ program
   .option('-m, --movies', 'Search by movies only. Cannot be used alongside \'series\' parameter')
   .option('-s --series', 'Search by series only. Cannot be used alongside \'movie\' parameter')
   .option('-o, --order-by [column]', 'Sort the search result by a column')
+  .option('-i, --info',
+  'Get averege season score for a series. Use this flag alongside --title flag. Will only work for series.',
+  )
   .parse(process.argv);
 
 if (program.movies && program.series) {
@@ -55,7 +58,11 @@ if (program.title) {
     sortColumn: program.orderBy,
     searchByType: IMDb.determineType({ movies: program.movies, series: program.series }),
   });
-  imdbInstance.search();
+  if (program.info) {
+    imdbInstance.seriesInfo();
+  } else {
+    imdbInstance.search();
+  }
 } else {
   // prompt the user for a search string
   inquirer.prompt(question).then((answer: any) => {

--- a/src/mock/seriesMock.ts
+++ b/src/mock/seriesMock.ts
@@ -1,5 +1,8 @@
 import { Episode, Season, Series } from '../types/series';
 
+export const SCORE_S01 = 5.3;
+export const SCORE_S02 = 4.6;
+
 export const EPISODES_S01 = [
   {
     Title: 'Series',
@@ -47,6 +50,14 @@ export const EPISODES_S02 = [
     imdbId: '1234',
   },
 ] as Episode[];
+
+export const EPISODES_S01_INVALID = [...EPISODES_S01, {
+  Title: 'Series',
+  Released: '',
+  Episode: 'Episode 1',
+  imdbRating: 'N/A',
+  imdbId: '1234',
+}];
 
 export const SEASON1 = {
   title: 'game of thrones',

--- a/src/types/searchResult.ts
+++ b/src/types/searchResult.ts
@@ -43,6 +43,11 @@ export interface FormattedItem {
   'IMDb ID': string;
 }
 
+export interface FormattedAverageSeason {
+  [key: string]: string;
+  'IMDb score': string;
+}
+
 export enum SearchResultType {
   Movies = 'movie',
   Series = 'series',

--- a/src/utils.test.ts
+++ b/src/utils.test.ts
@@ -53,12 +53,15 @@ describe('Utils functions', () => {
   });
   describe('calculateEpisodeAverageScore()', () => {
     it('should calulate average score based on episodes', () => {
-      expect(utils.calculateEpisodeAverageScore(seriesMock.EPISODES_S01)).toEqual(5.3);
+      expect(utils.calculateEpisodeAverageScore(seriesMock.EPISODES_S01)).toEqual(seriesMock.SCORE_S01);
+    });
+    it('should exluce episodes which has no valid score', () => {
+      expect(utils.calculateEpisodeAverageScore(seriesMock.EPISODES_S01_INVALID)).toEqual(seriesMock.SCORE_S01);
     });
   });
   describe('calculateSeasonAverageScore()', () => {
     it('should calculate average score based on a season', () => {
-      expect(utils.calculateSeasonAverageScore(seriesMock.SEASON1).AverageScore).toEqual(5.3);
+      expect(utils.calculateSeasonAverageScore(seriesMock.SEASON1).AverageScore).toEqual(seriesMock.SCORE_S01);
       expect(utils.calculateSeasonAverageScore(seriesMock.SEASON1).SeasonNumber)
       .toEqual(seriesMock.SEASON1.seasonNumber);
     });
@@ -67,8 +70,8 @@ describe('Utils functions', () => {
     it('should calculate average for each season in an entire series', () => {
       const seriesAverage = utils.calculateSeriesAverageScore(seriesMock.SERIES);
       expect(seriesAverage.Title).toEqual(seriesMock.SERIES.title);
-      expect(seriesAverage.Seasons[0].AverageScore).toEqual(5.3);
-      expect(seriesAverage.Seasons[1].AverageScore).toEqual(4.6);
+      expect(seriesAverage.Seasons[0].AverageScore).toEqual(seriesMock.SCORE_S01);
+      expect(seriesAverage.Seasons[1].AverageScore).toEqual(seriesMock.SCORE_S02);
     });
     it('should calculate average score for series taken from API', async () => {
       const series = await getFullSeriesFromTitle(utils.sanitizeQuery('game of thrones'));

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -31,7 +31,9 @@ export const calculateAverage = (arr: number[]): number => {
 };
 
 export const calculateEpisodeAverageScore = (episodes: Episode[]): number => {
-  const scores = episodes.map((episode) => parseFloat(episode.imdbRating));
+  const scores = episodes
+    .map((episode) => parseFloat(episode.imdbRating))
+    .filter((rating) => !isNaN(rating));
   return calculateAverage(scores);
 };
 


### PR DESCRIPTION
This PR implements a feature flag in the cli `-i --info` which can be used when searching for series to display a console.table of each season and their average imdb score - based on the scores of the individual episodes.

* New IMDB class method to calculate and render a console table
* Below and above average season scores will have either red or green colors in the table
* Fixed a bug where series with not yet rated episodes resulted in `Season 1 score N/A` since a average score was being calculated for "non numeric strings"