### PR TITLE
Fix for not yet aired seasons

### DIFF
--- a/src/mock/seriesMock.ts
+++ b/src/mock/seriesMock.ts
@@ -59,6 +59,14 @@ export const EPISODES_S01_INVALID = [...EPISODES_S01, {
   imdbId: '1234',
 }];
 
+export const EPISODE_NOT_RELEASED = {
+  Title: 'Series',
+  Released: 'N/A',
+  Episode: 'Episode 1',
+  imdbRating: 'N/A',
+  imdbId: '1234',
+};
+
 export const SEASON1 = {
   title: 'game of thrones',
   seasonNumber: 'Season 1',

--- a/src/utils.test.ts
+++ b/src/utils.test.ts
@@ -1,6 +1,7 @@
 import * as seriesMock from './mock/seriesMock';
 import { getFullSeriesFromTitle } from './omdbApi';
 import { SearchResultSortColumn, SearchResultSortOrder, SearchResultType, SortOrder } from './types/searchResult';
+import { Season } from './types/series';
 import * as utils from './utils';
 
 describe('Utils functions', () => {
@@ -65,6 +66,10 @@ describe('Utils functions', () => {
       expect(utils.calculateSeasonAverageScore(seriesMock.SEASON1).SeasonNumber)
       .toEqual(seriesMock.SEASON1.seasonNumber);
     });
+    it('should handle seasons not yet released', () => {
+      const invalidSeason = { ...seriesMock.SEASON1, episodes: [seriesMock.EPISODE_NOT_RELEASED] } as Season;
+      expect(utils.calculateSeasonAverageScore(invalidSeason).AverageScore).toEqual(utils.NOT_RELEASED_TEXT);
+    });
   });
   describe('calculateSeriesAverageScore()', () => {
     it('should calculate average for each season in an entire series', () => {
@@ -79,6 +84,19 @@ describe('Utils functions', () => {
       expect(seriesAverage.Title).toBeDefined();
       expect(seriesAverage.Seasons.length).toBeGreaterThan(1);
       seriesAverage.Seasons.map((season) => expect(season.AverageScore).toBeDefined());
+    });
+  });
+  describe('hasSeasonStarted', () => {
+    it('should return true if one or more episode is released', () => {
+      const season = {
+        ...seriesMock.SEASON1,
+        episodes: [...seriesMock.SEASON1.episodes, seriesMock.EPISODE_NOT_RELEASED],
+      };
+      expect(utils.hasSeasonStarted(season)).toBeTruthy();
+    });
+    it('should return false if all episodes has not released yet', () => {
+      const season = { ...seriesMock.SEASON1, episodes: [seriesMock.EPISODE_NOT_RELEASED] } as Season;
+      expect(utils.hasSeasonStarted(season)).toBeFalsy();
     });
   });
 });

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -2,6 +2,9 @@ import orderBy from 'lodash/orderBy';
 import { SortObject } from './types/searchResult';
 import { Episode, Season, SeasonAverageScore, Series, SeriesAverageScore } from './types/series';
 
+const NOT_RELEASED = 'N/A';
+export const NOT_RELEASED_TEXT = 'Not yet released';
+
 /**
  * Encode a string as a URI component
  * @param {String} query to encode
@@ -38,10 +41,9 @@ export const calculateEpisodeAverageScore = (episodes: Episode[]): number => {
 };
 
 export const calculateSeasonAverageScore = (season: Season) => {
-  const seasonAverage = calculateEpisodeAverageScore(season.episodes);
   return {
     SeasonNumber: season.seasonNumber,
-    AverageScore: seasonAverage,
+    AverageScore: hasSeasonStarted(season) ? calculateEpisodeAverageScore(season.episodes) : NOT_RELEASED_TEXT,
   } as SeasonAverageScore;
 };
 
@@ -50,4 +52,9 @@ export const calculateSeriesAverageScore = (series: Series) => {
     Title: series.title,
     Seasons: series.seasons.map((season) => calculateSeasonAverageScore(season)),
   } as SeriesAverageScore;
+};
+
+export const hasSeasonStarted = (season: Season): boolean => {
+  const airedEpisodes = season.episodes.filter((episode) => episode.Released !== NOT_RELEASED );
+  return !!airedEpisodes.length;
 };


### PR DESCRIPTION
This PR fixes a bug where entire seasons that has not aired yet resultet in a average score of `'N/A'`.
Now the utils function `utils.calculateSeasonAverageScore` will handle whether seasons has started yet or not. If no episodes in a season has aired yet calculations will not be performed and the average score will just be a string "Not aired yet"