### PR TITLE
Version 2.3.3

### DIFF
--- a/src/IMDb.test.ts
+++ b/src/IMDb.test.ts
@@ -31,12 +31,6 @@ describe('IMDb class', () => {
     });
   });
 
-  describe('getAPIKey()', () => {
-    it('should return the api key', () => {
-      expect(imdbInstance.getAPIKey()).not.toBeNull();
-    });
-  });
-
   describe('getSearchResult()', () => {
     it('should return search result for a given query', async () => {
       const response = await imdbInstance.getSearchResult(imdbInstance.query);
@@ -83,16 +77,6 @@ describe('IMDb class', () => {
     });
   });
 
-  describe('getTruncatedtext()', () => {
-    it('should properly truncate text', () => {
-      const text = imdbInstance.getTruncatedText(
-        'Harry, Ron, and Hermione search for Voldemort and other things that will be truncated', 40,
-      );
-      expect(text.includes('truncated')).not.toBeTruthy();
-      expect(text.includes('Harry, Ron, and Hermione search')).toBeTruthy();
-      expect(text.includes('...')).toBeTruthy();
-    });
-  });
   describe('getFormattedSearchResult()', () => {
     it('should return expected object', () => {
       const objFormatted = imdbInstance.getFormattedSearchResult({

--- a/src/IMDb.test.ts
+++ b/src/IMDb.test.ts
@@ -100,14 +100,4 @@ describe('IMDb class', () => {
       'Title,Year,Type,Plot,IMDb ID'.split(',').map((objKey: string) => expect(objFormatted).toHaveProperty(objKey));
     });
   });
-
-  describe('createSearchResult()', () => {
-    it('should add search results from a given array', () => {
-      const results = [{ Title: 'a' }, { Title: 'b' }];
-      expect(imdbInstance.results.length).toBe(0);
-      imdbInstance.createSearchResult(results);
-      expect(imdbInstance.results.length).toBe(results.length);
-      expect(imdbInstance.results[0].Title).toMatch(results[0].Title);
-    });
-  });
 });

--- a/src/IMDb.ts
+++ b/src/IMDb.ts
@@ -51,8 +51,6 @@ class IMDb implements IMDbProperties {
     return SearchResultType.All;
   }
   public query: string;
-  public originalQuery: string;
-  public results: FormattedItem[];
   public outputColor: (text: string) => string;
   public showPlot: boolean;
   public searchByType: SearchResultType;
@@ -73,9 +71,7 @@ class IMDb implements IMDbProperties {
     limitPlot = 40,
     sortColumn = SearchResultSortColumn.None,
   }) {
-    this.query = sanitizeQuery(query);
-    this.originalQuery = query;
-    this.results = [];
+    this.query = query;
     this.outputColor = chalk.hex('#f3ce13');
     this.showPlot = showPlot;
     this.searchByType = searchByType;
@@ -84,36 +80,31 @@ class IMDb implements IMDbProperties {
   }
 
   /**
-   * Push to results array
-   * @param {Array} results Array of result objects to later display
-   */
-  public createSearchResult(results: any[]): void {
-    results.forEach((result) => this.results.push(result));
-  }
-
-  /**
    * Render either a table with search results
    * or a message of no search results were found
    */
-  public renderSearchResults(): void {
-    if (Object.keys(this.results).length === 0) {
-      console.log(chalk.red(`\nCould not find any search results for '${this.originalQuery}'. Please try again.`));
-    } else if (this.availableColumnsToSort().includes(this.sortColumn)) {
-      console.table(this.getSortedSearchResult());
-    } else {
-      console.table(this.results);
+  public renderSearchResults(result?: FormattedItem[]): void {
+    if (!result) {
+      console.log(chalk.red(`\nCould not find any search results for '${this.query}'. Please try again.`));
+      return;
     }
+    if (this.availableColumnsToSort.includes(this.sortColumn)) {
+      console.table(this.getSortedSearchResult(result));
+      return;
+    }
+    console.table(result);
+    return;
   }
 
   /**
    * Get a sorted array of the search result
    */
-  public getSortedSearchResult() {
+  public getSortedSearchResult(result: FormattedItem[]) {
     const orderToSortBy = this.sortColumn === SearchResultSortColumn.Year ?
     SearchResultSortOrder.Descending
     : SearchResultSortOrder.Ascending;
     return sortByColumn({
-      items: this.results,
+      items: result,
       column: SortOrder[this.sortColumn],
       order: orderToSortBy,
     });
@@ -123,20 +114,22 @@ class IMDb implements IMDbProperties {
    * Get available values to sort by
    * @returns {Array}
    */
-  public availableColumnsToSort(): string[] {
+  get availableColumnsToSort(): SearchResultSortColumn[] {
     return [SearchResultSortColumn.Year, SearchResultSortColumn.Title];
   }
 
   /**
-   * Get search result promise by query
+   * Get search result promise by query.
+   * Method will sanitize the input query
    * @param {String} query
    * @returns {Promise}
    */
   public async getSearchResult(query: string): Promise<Item[]> {
+    const sanitizedQuery = sanitizeQuery(query);
     if (this.searchByType === SearchResultType.All) {
-      return searchByQuery(query);
+      return searchByQuery(sanitizedQuery);
     }
-    return searchByQueryAndType(query, this.searchByType);
+    return searchByQueryAndType(sanitizedQuery, this.searchByType);
   }
 
   /**
@@ -187,18 +180,17 @@ class IMDb implements IMDbProperties {
         this.renderSearchResults();
         process.exit();
       }
+      let searchResult;
       if (this.showPlot) {
         const results = await this.getFullItemsByIMDBIds(itemsByQuery.map((res) => res.imdbID));
-        const searchResult = results.map(
+        searchResult = results.map(
           (result: Item) => this.getFormattedSearchResult(result, this.showPlot),
-        );
-        this.createSearchResult(searchResult);
+        ) as FormattedItem[];
       } else {
-        const searchResult = itemsByQuery.map((result: Item) => this.getFormattedSearchResult(result));
-        this.createSearchResult(searchResult);
+        searchResult = itemsByQuery.map((result: Item) => this.getFormattedSearchResult(result));
       }
       spinner.stop();
-      this.renderSearchResults();
+      this.renderSearchResults(searchResult);
 
     } catch (e) {
       spinner.stop();

--- a/src/index.ts
+++ b/src/index.ts
@@ -24,6 +24,9 @@ program
   .option('-m, --movies', 'Search by movies only. Cannot be used alongside \'series\' parameter')
   .option('-s --series', 'Search by series only. Cannot be used alongside \'movie\' parameter')
   .option('-o, --order-by [column]', 'Sort the search result by a column')
+  .option('-i, --info',
+  'Get averege season score for a series. Use this flag alongside --title flag. Will only work for series.',
+  )
   .parse(process.argv);
 
 if (program.movies && program.series) {
@@ -55,7 +58,11 @@ if (program.title) {
     sortColumn: program.orderBy,
     searchByType: IMDb.determineType({ movies: program.movies, series: program.series }),
   });
-  imdbInstance.search();
+  if (program.info) {
+    imdbInstance.seriesInfo();
+  } else {
+    imdbInstance.search();
+  }
 } else {
   // prompt the user for a search string
   inquirer.prompt(question).then((answer: any) => {

--- a/src/mock/seriesMock.ts
+++ b/src/mock/seriesMock.ts
@@ -1,5 +1,8 @@
 import { Episode, Season, Series } from '../types/series';
 
+export const SCORE_S01 = 5.3;
+export const SCORE_S02 = 4.6;
+
 export const EPISODES_S01 = [
   {
     Title: 'Series',
@@ -47,6 +50,14 @@ export const EPISODES_S02 = [
     imdbId: '1234',
   },
 ] as Episode[];
+
+export const EPISODES_S01_INVALID = [...EPISODES_S01, {
+  Title: 'Series',
+  Released: '',
+  Episode: 'Episode 1',
+  imdbRating: 'N/A',
+  imdbId: '1234',
+}];
 
 export const SEASON1 = {
   title: 'game of thrones',

--- a/src/mock/seriesMock.ts
+++ b/src/mock/seriesMock.ts
@@ -59,6 +59,14 @@ export const EPISODES_S01_INVALID = [...EPISODES_S01, {
   imdbId: '1234',
 }];
 
+export const EPISODE_NOT_RELEASED = {
+  Title: 'Series',
+  Released: 'N/A',
+  Episode: 'Episode 1',
+  imdbRating: 'N/A',
+  imdbId: '1234',
+};
+
 export const SEASON1 = {
   title: 'game of thrones',
   seasonNumber: 'Season 1',

--- a/src/mock/seriesMock.ts
+++ b/src/mock/seriesMock.ts
@@ -1,0 +1,69 @@
+import { Episode, Season, Series } from '../types/series';
+
+export const EPISODES_S01 = [
+  {
+    Title: 'Series',
+    Released: '',
+    Episode: 'Episode 1',
+    imdbRating: '5.5',
+    imdbId: '1234',
+  },
+  {
+    Title: 'Series',
+    Released: '',
+    Episode: 'Episode 2',
+    imdbRating: '7.3',
+    imdbId: '1234',
+  },
+  {
+    Title: 'Series',
+    Released: '',
+    Episode: 'Episode 3',
+    imdbRating: '3.2',
+    imdbId: '1234',
+  },
+] as Episode[];
+
+export const EPISODES_S02 = [
+  {
+    Title: 'Series 2',
+    Released: '',
+    Episode: 'Episode 1',
+    imdbRating: '7.2',
+    imdbId: '1234',
+  },
+  {
+    Title: 'Series 2',
+    Released: '',
+    Episode: 'Episode 2',
+    imdbRating: '2.3',
+    imdbId: '1234',
+  },
+  {
+    Title: 'Series 3',
+    Released: '',
+    Episode: 'Episode 3',
+    imdbRating: '4.2',
+    imdbId: '1234',
+  },
+] as Episode[];
+
+export const SEASON1 = {
+  title: 'game of thrones',
+  seasonNumber: 'Season 1',
+  totalSeasons: '8',
+  episodes: EPISODES_S01,
+} as Season;
+
+export const SEASON2 = {
+  title: 'game of thrones',
+  seasonNumber: 'Season 2',
+  totalSeasons: '8',
+  episodes: EPISODES_S02,
+} as Season;
+
+export const SERIES = {
+  title: SEASON1.title,
+  totalSeasons: SEASON1.totalSeasons,
+  seasons: [SEASON1, SEASON2],
+} as Series;

--- a/src/omdbApi.test.ts
+++ b/src/omdbApi.test.ts
@@ -1,0 +1,65 @@
+  import * as omdbApi from './omdbApi';
+  import { SearchResultType } from './types/searchResult';
+  import { sanitizeQuery } from './utils';
+
+  describe('OMDb API Functions', () => {
+  describe('searchByQuery()', () => {
+    it('should get search result for a given query', async () => {
+      const items = await omdbApi.searchByQuery(sanitizeQuery('Harry potter'));
+      expect(items.length).toBeGreaterThan(1);
+    });
+  });
+  describe('searchByQueryAndType()', () => {
+    it('should get search result for a given query and type', async () => {
+      const items = await omdbApi.searchByQueryAndType(sanitizeQuery('Star wars'), SearchResultType.Series);
+      items.map((item) => expect(item.Type).toEqual(SearchResultType.Series));
+    });
+  });
+  describe('getItemById()', () => {
+    it('should get a given item for a imdb id', async () => {
+      const id = 'tt1201607';
+      const item = await omdbApi.getItemById(id);
+      expect(item.imdbID).toEqual(id);
+    });
+  });
+  describe('getItemsByIds()', () => {
+    it('should get a given items for imdb ids', async () => {
+      const ids = ['tt1201607', 'tt0241527'];
+      const items = await omdbApi.getItemsByIds(ids);
+      const resultItds = items.map((item) => item.imdbID);
+      resultItds.map((id) => expect(ids.includes(id)).toEqual(true));
+    });
+  });
+  describe('getSeasonFromTitle()', () => {
+    it('should get a specific season for a given title', async () => {
+      const title = sanitizeQuery('Game of thrones');
+      const season = await omdbApi.getSeasonFromTitle(title, 1);
+      expect(season.seasonNumber).toEqual('1');
+    });
+  });
+  describe('getSeasonFromId()', () => {
+    it('should get a specific season for a given imdb id', async () => {
+      const id = 'tt0944947';
+      const season = await omdbApi.getSeasonFromId(id, 1);
+      expect(season.seasonNumber).toEqual('1');
+    });
+  });
+  describe('getAllSeasonsFromId()', () => {
+    it('should get full series for a given imdb id', async () => {
+      const id = 'tt0944947';
+      const series = await omdbApi.getFullSeriesFromId(id);
+      expect(series.title).toBeDefined();
+      expect(series.totalSeasons).toBeDefined();
+      expect(series.seasons.length).toBeGreaterThan(0);
+    });
+  });
+  describe('getAllSeasonsFromTitle()', () => {
+    it('should get full series for a given title', async () => {
+      const title = sanitizeQuery('game of thrones');
+      const series = await omdbApi.getFullSeriesFromTitle(title);
+      expect(series.title).toBe('Game of Thrones');
+      expect(series.totalSeasons).toBeDefined();
+      expect(series.seasons.length).toBeGreaterThan(0);
+    });
+  });
+});

--- a/src/omdbApi.test.ts
+++ b/src/omdbApi.test.ts
@@ -51,6 +51,8 @@
       expect(series.title).toBeDefined();
       expect(series.totalSeasons).toBeDefined();
       expect(series.seasons.length).toBeGreaterThan(0);
+      expect(series.seasons[0].title).toBeDefined();
+      expect(series.seasons[0].episodes[0].imdbRating).toBeDefined();
     });
   });
   describe('getAllSeasonsFromTitle()', () => {
@@ -60,6 +62,8 @@
       expect(series.title).toBe('Game of Thrones');
       expect(series.totalSeasons).toBeDefined();
       expect(series.seasons.length).toBeGreaterThan(0);
+      expect(series.seasons[0].title).toBeDefined();
+      expect(series.seasons[0].episodes[0].imdbRating).toBeDefined();
     });
   });
 });

--- a/src/omdbApi.ts
+++ b/src/omdbApi.ts
@@ -9,7 +9,7 @@ const BASE_URL = `http://www.omdbapi.com?apikey=${API_KEY}`;
 const getNumberOfSeasons = (title: string, amount: number) => {
   const seasonsPromises = [];
   for (let i = 1; i <= amount; i++) {
-    seasonsPromises.push(getSeasonFromTitle(sanitizeQuery(title), i));
+    seasonsPromises.push(getSeasonFromTitle(title, i));
  }
   return seasonsPromises;
 };
@@ -60,7 +60,7 @@ export const getFullSeriesFromId = async (id: string) => {
 
 export const getFullSeriesFromTitle = async (title: string) => {
   const { totalSeasons, title: seriesTitle } = await getSeasonFromTitle(title, 1);
-  const seasons = await Promise.all(getNumberOfSeasons(sanitizeQuery(title), parseInt(totalSeasons, 10)));
+  const seasons = await Promise.all(getNumberOfSeasons(sanitizeQuery(seriesTitle), parseInt(totalSeasons, 10)));
   return {
     title: seriesTitle,
     totalSeasons,

--- a/src/omdbApi.ts
+++ b/src/omdbApi.ts
@@ -1,8 +1,27 @@
 const axios = require('axios');
-import {FullItem, Item, SearchResultType} from './types/searchResult';
+import { FullItem, Item, SearchResultType } from './types/searchResult';
+import { Season, Series } from './types/series';
+import { sanitizeQuery } from './utils';
 
 const API_KEY = process.env.API_KEY;
 const BASE_URL = `http://www.omdbapi.com?apikey=${API_KEY}`;
+
+const getNumberOfSeasons = (title: string, amount: number) => {
+  const seasonsPromises = [];
+  for (let i = 1; i <= amount; i++) {
+    seasonsPromises.push(getSeasonFromTitle(sanitizeQuery(title), i));
+ }
+  return seasonsPromises;
+};
+
+const formatSeason = (data: any): Season => {
+  return {
+    title: data.Title,
+    seasonNumber: data.Season,
+    totalSeasons: data.totalSeasons,
+    episodes: data.Episodes,
+  };
+};
 
 export const searchByQuery = async (query: string): Promise<Item[]> => {
   const { data } = await axios.get(`${BASE_URL}&s=${query}`);
@@ -22,4 +41,29 @@ export const getItemById = async (id: string): Promise<FullItem> => {
 export const getItemsByIds = async (ids: string[]): Promise<FullItem[]> => {
   const items = await Promise.all(ids.map((id: string) => getItemById(id)));
   return items as FullItem[];
+};
+
+export const getSeasonFromTitle = async (title: string, season: number) => {
+  const { data } = await axios.get(`${BASE_URL}&t=${title}&Season=${season}`);
+  return formatSeason(data);
+};
+
+export const getSeasonFromId = async (id: string, season: number) => {
+  const { data } = await axios.get(`${BASE_URL}&i=${id}&Season=${season}`);
+  return formatSeason(data);
+};
+
+export const getFullSeriesFromId = async (id: string) => {
+  const { title } = await getSeasonFromId(id, 1);
+  return getFullSeriesFromTitle(title);
+};
+
+export const getFullSeriesFromTitle = async (title: string) => {
+  const { totalSeasons, title: seriesTitle } = await getSeasonFromTitle(title, 1);
+  const seasons = await Promise.all(getNumberOfSeasons(sanitizeQuery(title), parseInt(totalSeasons, 10)));
+  return {
+    title: seriesTitle,
+    totalSeasons,
+    seasons,
+  } as Series;
 };

--- a/src/omdbApi.ts
+++ b/src/omdbApi.ts
@@ -1,0 +1,25 @@
+const axios = require('axios');
+import {FullItem, Item, SearchResultType} from './types/searchResult';
+
+const API_KEY = process.env.API_KEY;
+const BASE_URL = `http://www.omdbapi.com?apikey=${API_KEY}`;
+
+export const searchByQuery = async (query: string): Promise<Item[]> => {
+  const { data } = await axios.get(`${BASE_URL}&s=${query}`);
+  return data.Search as Item[];
+};
+
+export const searchByQueryAndType = async (query: string, type: SearchResultType): Promise<Item[]> => {
+  const { data } = await axios.get(`${BASE_URL}&s=${query}&type=${type}`);
+  return data.Search as Item[];
+};
+
+export const getItemById = async (id: string): Promise<FullItem> => {
+  const { data } = await axios.get(`${BASE_URL}&i=${id}`);
+  return data as FullItem;
+};
+
+export const getItemsByIds = async (ids: string[]): Promise<FullItem[]> => {
+  const items = await Promise.all(ids.map((id: string) => getItemById(id)));
+  return items as FullItem[];
+};

--- a/src/types/imdb.ts
+++ b/src/types/imdb.ts
@@ -1,9 +1,5 @@
-import { FormattedItem } from './searchResult';
-
 export interface IMDbProperties {
   query: string;
-  originalQuery: string;
-  results: FormattedItem[];
   outputColor: (text: string) => string;
   showPlot: boolean;
   searchByType: string;

--- a/src/types/imdb.ts
+++ b/src/types/imdb.ts
@@ -3,7 +3,6 @@ import { FormattedItem } from './searchResult';
 export interface IMDbProperties {
   query: string;
   originalQuery: string;
-  baseUrl: string;
   results: FormattedItem[];
   outputColor: (text: string) => string;
   showPlot: boolean;

--- a/src/types/searchResult.ts
+++ b/src/types/searchResult.ts
@@ -43,6 +43,11 @@ export interface FormattedItem {
   'IMDb ID': string;
 }
 
+export interface FormattedAverageSeason {
+  [key: string]: string;
+  'IMDb score': string;
+}
+
 export enum SearchResultType {
   Movies = 'movie',
   Series = 'series',

--- a/src/types/series.ts
+++ b/src/types/series.ts
@@ -18,3 +18,13 @@ export interface Series {
   totalSeasons: string;
   seasons: Season[];
 }
+
+export interface SeasonAverageScore {
+  SeasonNumber: string;
+  AverageScore: number;
+}
+
+export interface SeriesAverageScore {
+  Title: string;
+  Seasons: SeasonAverageScore[];
+}

--- a/src/types/series.ts
+++ b/src/types/series.ts
@@ -1,0 +1,20 @@
+export interface Season {
+  title: string;
+  seasonNumber: string;
+  totalSeasons: string;
+  episodes: Episode[];
+ }
+
+export interface Episode {
+  Title: string;
+  Released: string;
+  Episode: string;
+  imdbRating: string;
+  imdbId: string;
+}
+
+export interface Series {
+  title: string;
+  totalSeasons: string;
+  seasons: Season[];
+}

--- a/src/utils.test.ts
+++ b/src/utils.test.ts
@@ -1,6 +1,7 @@
 import * as seriesMock from './mock/seriesMock';
 import { getFullSeriesFromTitle } from './omdbApi';
 import { SearchResultSortColumn, SearchResultSortOrder, SearchResultType, SortOrder } from './types/searchResult';
+import { Season } from './types/series';
 import * as utils from './utils';
 
 describe('Utils functions', () => {
@@ -65,6 +66,10 @@ describe('Utils functions', () => {
       expect(utils.calculateSeasonAverageScore(seriesMock.SEASON1).SeasonNumber)
       .toEqual(seriesMock.SEASON1.seasonNumber);
     });
+    it('should handle seasons not yet released', () => {
+      const invalidSeason = { ...seriesMock.SEASON1, episodes: [seriesMock.EPISODE_NOT_RELEASED] } as Season;
+      expect(utils.calculateSeasonAverageScore(invalidSeason).AverageScore).toEqual(utils.NOT_RELEASED_TEXT);
+    });
   });
   describe('calculateSeriesAverageScore()', () => {
     it('should calculate average for each season in an entire series', () => {
@@ -79,6 +84,19 @@ describe('Utils functions', () => {
       expect(seriesAverage.Title).toBeDefined();
       expect(seriesAverage.Seasons.length).toBeGreaterThan(1);
       seriesAverage.Seasons.map((season) => expect(season.AverageScore).toBeDefined());
+    });
+  });
+  describe('hasSeasonStarted', () => {
+    it('should return true if one or more episode is released', () => {
+      const season = {
+        ...seriesMock.SEASON1,
+        episodes: [...seriesMock.SEASON1.episodes, seriesMock.EPISODE_NOT_RELEASED],
+      };
+      expect(utils.hasSeasonStarted(season)).toBeTruthy();
+    });
+    it('should return false if all episodes has not released yet', () => {
+      const season = { ...seriesMock.SEASON1, episodes: [seriesMock.EPISODE_NOT_RELEASED] } as Season;
+      expect(utils.hasSeasonStarted(season)).toBeFalsy();
     });
   });
 });

--- a/src/utils.test.ts
+++ b/src/utils.test.ts
@@ -1,23 +1,25 @@
+import * as seriesMock from './mock/seriesMock';
+import { getFullSeriesFromTitle } from './omdbApi';
 import { SearchResultSortColumn, SearchResultSortOrder, SearchResultType, SortOrder } from './types/searchResult';
-import { sanitizeQuery, sortByColumn, truncate } from './utils';
+import * as utils from './utils';
 
 describe('Utils functions', () => {
   describe('sanitizeQuery()', () => {
     it('should be defined', () => {
-      expect(sanitizeQuery).toBeDefined();
+      expect(utils.sanitizeQuery).toBeDefined();
     });
     it('should sanitize a passed query', () => {
       const query = 'harry potter';
-      expect(sanitizeQuery(query)).toMatch('harry%20potter');
+      expect(utils.sanitizeQuery(query)).toMatch('harry%20potter');
     });
     it('should not sanitize if not needed', () => {
       const query = 'Interstellar';
-      expect(sanitizeQuery(query)).toMatch(query);
+      expect(utils.sanitizeQuery(query)).toMatch(query);
     });
   });
   describe('sortColumn()', () => {
     it('should be defined', () => {
-      expect(sortByColumn).toBeDefined();
+      expect(utils.sortByColumn).toBeDefined();
     });
     it('should sort array of columns', () => {
       const items = [
@@ -25,12 +27,12 @@ describe('Utils functions', () => {
         { 'Title': 'b', 'Year': '3', 'Type': SearchResultType.Movies, 'IMDb ID': '1' },
         { 'Title': 'c', 'Year': '1', 'Type': SearchResultType.Movies, 'IMDb ID': '3' },
       ];
-      const sortedByTitle = sortByColumn({
+      const sortedByTitle = utils.sortByColumn({
         items,
         column: SortOrder[SearchResultSortColumn.Title],
         order: SearchResultSortOrder.Ascending,
       });
-      const sortedByYear = sortByColumn({
+      const sortedByYear = utils.sortByColumn({
         items,
         column: SortOrder[SearchResultSortColumn.Year],
         order: SearchResultSortOrder.Descending,
@@ -41,12 +43,39 @@ describe('Utils functions', () => {
   });
   describe('truncate()', () => {
     it('should properly truncate text', () => {
-      const text = truncate(
+      const text = utils.truncate(
         'Harry, Ron, and Hermione search for Voldemort and other things that will be truncated', 40,
       );
       expect(text.includes('truncated')).not.toBeTruthy();
       expect(text.includes('Harry, Ron, and Hermione search')).toBeTruthy();
       expect(text.includes('...')).toBeTruthy();
+    });
+  });
+  describe('calculateEpisodeAverageScore()', () => {
+    it('should calulate average score based on episodes', () => {
+      expect(utils.calculateEpisodeAverageScore(seriesMock.EPISODES_S01)).toEqual(5.3);
+    });
+  });
+  describe('calculateSeasonAverageScore()', () => {
+    it('should calculate average score based on a season', () => {
+      expect(utils.calculateSeasonAverageScore(seriesMock.SEASON1).AverageScore).toEqual(5.3);
+      expect(utils.calculateSeasonAverageScore(seriesMock.SEASON1).SeasonNumber)
+      .toEqual(seriesMock.SEASON1.seasonNumber);
+    });
+  });
+  describe('calculateSeriesAverageScore()', () => {
+    it('should calculate average for each season in an entire series', () => {
+      const seriesAverage = utils.calculateSeriesAverageScore(seriesMock.SERIES);
+      expect(seriesAverage.Title).toEqual(seriesMock.SERIES.title);
+      expect(seriesAverage.Seasons[0].AverageScore).toEqual(5.3);
+      expect(seriesAverage.Seasons[1].AverageScore).toEqual(4.6);
+    });
+    it('should calculate average score for series taken from API', async () => {
+      const series = await getFullSeriesFromTitle(utils.sanitizeQuery('game of thrones'));
+      const seriesAverage = utils.calculateSeriesAverageScore(series);
+      expect(seriesAverage.Title).toBeDefined();
+      expect(seriesAverage.Seasons.length).toBeGreaterThan(1);
+      seriesAverage.Seasons.map((season) => expect(season.AverageScore).toBeDefined());
     });
   });
 });

--- a/src/utils.test.ts
+++ b/src/utils.test.ts
@@ -1,5 +1,5 @@
 import { SearchResultSortColumn, SearchResultSortOrder, SearchResultType, SortOrder } from './types/searchResult';
-import { sanitizeQuery, sortByColumn } from './utils';
+import { sanitizeQuery, sortByColumn, truncate } from './utils';
 
 describe('Utils functions', () => {
   describe('sanitizeQuery()', () => {
@@ -37,6 +37,16 @@ describe('Utils functions', () => {
       });
       expect(sortedByTitle[0].Title).toMatch('a');
       expect(sortedByYear[0].Year === '3').toBeTruthy();
+    });
+  });
+  describe('truncate()', () => {
+    it('should properly truncate text', () => {
+      const text = truncate(
+        'Harry, Ron, and Hermione search for Voldemort and other things that will be truncated', 40,
+      );
+      expect(text.includes('truncated')).not.toBeTruthy();
+      expect(text.includes('Harry, Ron, and Hermione search')).toBeTruthy();
+      expect(text.includes('...')).toBeTruthy();
     });
   });
 });

--- a/src/utils.test.ts
+++ b/src/utils.test.ts
@@ -53,12 +53,15 @@ describe('Utils functions', () => {
   });
   describe('calculateEpisodeAverageScore()', () => {
     it('should calulate average score based on episodes', () => {
-      expect(utils.calculateEpisodeAverageScore(seriesMock.EPISODES_S01)).toEqual(5.3);
+      expect(utils.calculateEpisodeAverageScore(seriesMock.EPISODES_S01)).toEqual(seriesMock.SCORE_S01);
+    });
+    it('should exluce episodes which has no valid score', () => {
+      expect(utils.calculateEpisodeAverageScore(seriesMock.EPISODES_S01_INVALID)).toEqual(seriesMock.SCORE_S01);
     });
   });
   describe('calculateSeasonAverageScore()', () => {
     it('should calculate average score based on a season', () => {
-      expect(utils.calculateSeasonAverageScore(seriesMock.SEASON1).AverageScore).toEqual(5.3);
+      expect(utils.calculateSeasonAverageScore(seriesMock.SEASON1).AverageScore).toEqual(seriesMock.SCORE_S01);
       expect(utils.calculateSeasonAverageScore(seriesMock.SEASON1).SeasonNumber)
       .toEqual(seriesMock.SEASON1.seasonNumber);
     });
@@ -67,8 +70,8 @@ describe('Utils functions', () => {
     it('should calculate average for each season in an entire series', () => {
       const seriesAverage = utils.calculateSeriesAverageScore(seriesMock.SERIES);
       expect(seriesAverage.Title).toEqual(seriesMock.SERIES.title);
-      expect(seriesAverage.Seasons[0].AverageScore).toEqual(5.3);
-      expect(seriesAverage.Seasons[1].AverageScore).toEqual(4.6);
+      expect(seriesAverage.Seasons[0].AverageScore).toEqual(seriesMock.SCORE_S01);
+      expect(seriesAverage.Seasons[1].AverageScore).toEqual(seriesMock.SCORE_S02);
     });
     it('should calculate average score for series taken from API', async () => {
       const series = await getFullSeriesFromTitle(utils.sanitizeQuery('game of thrones'));

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -2,6 +2,9 @@ import orderBy from 'lodash/orderBy';
 import { SortObject } from './types/searchResult';
 import { Episode, Season, SeasonAverageScore, Series, SeriesAverageScore } from './types/series';
 
+const NOT_RELEASED = 'N/A';
+export const NOT_RELEASED_TEXT = 'Not yet released';
+
 /**
  * Encode a string as a URI component
  * @param {String} query to encode
@@ -38,10 +41,9 @@ export const calculateEpisodeAverageScore = (episodes: Episode[]): number => {
 };
 
 export const calculateSeasonAverageScore = (season: Season) => {
-  const seasonAverage = calculateEpisodeAverageScore(season.episodes);
   return {
     SeasonNumber: season.seasonNumber,
-    AverageScore: seasonAverage,
+    AverageScore: hasSeasonStarted(season) ? calculateEpisodeAverageScore(season.episodes) : NOT_RELEASED_TEXT,
   } as SeasonAverageScore;
 };
 
@@ -50,4 +52,9 @@ export const calculateSeriesAverageScore = (series: Series) => {
     Title: series.title,
     Seasons: series.seasons.map((season) => calculateSeasonAverageScore(season)),
   } as SeriesAverageScore;
+};
+
+export const hasSeasonStarted = (season: Season): boolean => {
+  const airedEpisodes = season.episodes.filter((episode) => episode.Released !== NOT_RELEASED );
+  return !!airedEpisodes.length;
 };

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -31,7 +31,9 @@ export const calculateAverage = (arr: number[]): number => {
 };
 
 export const calculateEpisodeAverageScore = (episodes: Episode[]): number => {
-  const scores = episodes.map((episode) => parseFloat(episode.imdbRating));
+  const scores = episodes
+    .map((episode) => parseFloat(episode.imdbRating))
+    .filter((rating) => !isNaN(rating));
   return calculateAverage(scores);
 };
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -25,12 +25,12 @@ export const sortByColumn = ({ items, column, order }: SortObject) => orderBy(it
  */
 export const truncate = (text: string, limit: number): string => text ?  `${text.substring(0, limit)}...` : '';
 
-export const calculateAverage = (arr: number[]) => {
+export const calculateAverage = (arr: number[]): number => {
   const average = arr.reduce((a, b) => a + b, 0) / arr.length;
   return parseFloat(average.toFixed(1));
 };
 
-export const calculateEpisodeAverageScore = (episodes: Episode[]) => {
+export const calculateEpisodeAverageScore = (episodes: Episode[]): number => {
   const scores = episodes.map((episode) => parseFloat(episode.imdbRating));
   return calculateAverage(scores);
 };

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -15,3 +15,11 @@ export const sanitizeQuery = (query: string) => encodeURIComponent(query);
  * @param {String} order asc or desc
  */
 export const sortByColumn = ({ items, column, order }: SortObject) => orderBy(items, [column], [order]);
+
+/**
+ * Truncate text
+ * @param {String} text
+ * @param {Number} limit
+ * @returns {String}
+ */
+export const truncate = (text: string, limit: number): string => text ?  `${text.substring(0, limit)}...` : '';

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,5 +1,6 @@
 import orderBy from 'lodash/orderBy';
 import { SortObject } from './types/searchResult';
+import { Episode, Season, SeasonAverageScore, Series, SeriesAverageScore } from './types/series';
 
 /**
  * Encode a string as a URI component
@@ -23,3 +24,28 @@ export const sortByColumn = ({ items, column, order }: SortObject) => orderBy(it
  * @returns {String}
  */
 export const truncate = (text: string, limit: number): string => text ?  `${text.substring(0, limit)}...` : '';
+
+export const calculateAverage = (arr: number[]) => {
+  const average = arr.reduce((a, b) => a + b, 0) / arr.length;
+  return parseFloat(average.toFixed(1));
+};
+
+export const calculateEpisodeAverageScore = (episodes: Episode[]) => {
+  const scores = episodes.map((episode) => parseFloat(episode.imdbRating));
+  return calculateAverage(scores);
+};
+
+export const calculateSeasonAverageScore = (season: Season) => {
+  const seasonAverage = calculateEpisodeAverageScore(season.episodes);
+  return {
+    SeasonNumber: season.seasonNumber,
+    AverageScore: seasonAverage,
+  } as SeasonAverageScore;
+};
+
+export const calculateSeriesAverageScore = (series: Series) => {
+  return {
+    Title: series.title,
+    Seasons: series.seasons.map((season) => calculateSeasonAverageScore(season)),
+  } as SeriesAverageScore;
+};


### PR DESCRIPTION
This PR marks the release 2.3.3 of the cli - which focuses on getting and displaying series average season scores.

The command flag `-i` is to be used like this: `imdb -t 'lost' -i` will find the series lost, calculate season average score based on individual episodes from each season and display season average score in a console.table. 

PR included:
* #28 
* #29 
* #30 
* #31 
* #32 
* #33 
* #34 