### PR TITLE
Refactor omdb request request handling

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -552,6 +552,12 @@
       "integrity": "sha512-Uy0PN4R5vgBUXFoJrKryf5aTk3kJ8Rv3PdlHjl6UaX+Cqp1QE0yPQ68MPXGrZOfG7gZVNDIJZYyot0B9ubXUrQ==",
       "dev": true
     },
+    "@types/querystringify": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@types/querystringify/-/querystringify-2.0.0.tgz",
+      "integrity": "sha512-9WgEGTevECrXJC2LSWPqiPYWq8BRmeaOyZn47js/3V6UF0PWtcVfvvR43YjeO8BzBsthTz98jMczujOwTw+WYg==",
+      "dev": true
+    },
     "@types/stack-utils": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-1.0.1.tgz",
@@ -4466,6 +4472,11 @@
       "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
       "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA==",
       "dev": true
+    },
+    "querystringify": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/querystringify/-/querystringify-2.1.1.tgz",
+      "integrity": "sha512-w7fLxIRCRT7U8Qu53jQnJyPkYZIaR4n5151KMfcJlO/A9397Wxb1amJvROTK6TOnp7PfoAmg/qXiNHI+08jRfA=="
     },
     "react-is": {
       "version": "16.8.6",

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "inquirer": "^7.0.1",
     "lodash": "^4.17.13",
     "ora": "^4.0.3",
+    "querystringify": "^2.1.1",
     "table-master": "^1.0.3"
   },
   "devDependencies": {
@@ -36,6 +37,7 @@
     "@types/jest": "^24.0.15",
     "@types/lodash": "^4.14.135",
     "@types/node": "^12.0.12",
+    "@types/querystringify": "^2.0.0",
     "jest": "^24.8.0",
     "prettier": "^1.18.2",
     "ts-jest": "^24.0.2",

--- a/src/cli/IMDb.ts
+++ b/src/cli/IMDb.ts
@@ -6,7 +6,7 @@ import {
   searchByQuery,
   searchByQueryAndType,
 } from '../lib/omdbApi';
-import { calculateAverage, calculateSeriesAverageScore, sanitizeQuery, sortByColumn, truncate } from '../lib/utils';
+import { calculateAverage, calculateSeriesAverageScore, sortByColumn, truncate } from '../lib/utils';
 import { IMDbProperties } from '../types/imdb';
 import {
   FormattedAverageSeason,
@@ -121,11 +121,10 @@ export class IMDb implements IMDbProperties {
    * @returns {Promise}
    */
   public async getSearchResult(query: string): Promise<Item[]> {
-    const sanitizedQuery = sanitizeQuery(query);
     if (this.searchByType === SearchResultType.All) {
-      return searchByQuery(sanitizedQuery);
+      return searchByQuery(query);
     }
-    return searchByQueryAndType(sanitizedQuery, this.searchByType);
+    return searchByQueryAndType(query, this.searchByType);
   }
 
   /**

--- a/src/lib/omdbApi.test.ts
+++ b/src/lib/omdbApi.test.ts
@@ -1,17 +1,16 @@
 import { SearchResultType } from '../types/searchResult';
 import * as omdbApi from './omdbApi';
-import { sanitizeQuery } from './utils';
 
 describe('OMDb API Functions', () => {
   describe('searchByQuery()', () => {
     it('should get search result for a given query', async () => {
-      const items = await omdbApi.searchByQuery(sanitizeQuery('Harry potter'));
+      const items = await omdbApi.searchByQuery('Harry potter');
       expect(items.length).toBeGreaterThan(1);
     });
   });
   describe('searchByQueryAndType()', () => {
     it('should get search result for a given query and type', async () => {
-      const items = await omdbApi.searchByQueryAndType(sanitizeQuery('Star wars'), SearchResultType.Series);
+      const items = await omdbApi.searchByQueryAndType('Star wars', SearchResultType.Series);
       items.map((item) => expect(item.Type).toEqual(SearchResultType.Series));
     });
   });
@@ -32,7 +31,7 @@ describe('OMDb API Functions', () => {
   });
   describe('getSeasonFromTitle()', () => {
     it('should get a specific season for a given title', async () => {
-      const title = sanitizeQuery('Game of thrones');
+      const title = 'Game of thrones';
       const season = await omdbApi.getSeasonFromTitle(title, 1);
       expect(season.seasonNumber).toEqual('1');
     });
@@ -57,7 +56,7 @@ describe('OMDb API Functions', () => {
   });
   describe('getAllSeasonsFromTitle()', () => {
     it('should get full series for a given title', async () => {
-      const title = sanitizeQuery('game of thrones');
+      const title = 'game of thrones';
       const series = await omdbApi.getFullSeriesFromTitle(title);
       expect(series.title).toBe('Game of Thrones');
       expect(series.totalSeasons).toBeDefined();

--- a/src/lib/omdbApi.ts
+++ b/src/lib/omdbApi.ts
@@ -1,10 +1,22 @@
-import axios from 'axios';
 import { FullItem, Item, SearchResultType } from '../types/searchResult';
 import { Season, Series } from '../types/series';
-import { sanitizeQuery } from './utils';
+import * as request from './request';
 
 const API_KEY = process.env.API_KEY;
-const BASE_URL = `http://www.omdbapi.com?apikey=${API_KEY}`;
+const BASE_URL = `http://www.omdbapi.com`;
+const API_PARAM = {
+  apikey: API_KEY,
+};
+
+interface RequestParams {
+  s?: string;
+  t?: string;
+  type?: SearchResultType;
+  i?: string;
+  Season?: number;
+}
+
+const get = (params: RequestParams) => request.get(BASE_URL, { ...API_PARAM, ...params });
 
 const getNumberOfSeasons = (title: string, amount: number) => {
   const seasonsPromises = [];
@@ -14,27 +26,25 @@ const getNumberOfSeasons = (title: string, amount: number) => {
   return seasonsPromises;
 };
 
-const formatSeason = (data: any): Season => {
-  return {
-    title: data.Title,
-    seasonNumber: data.Season,
-    totalSeasons: data.totalSeasons,
-    episodes: data.Episodes,
-  };
-};
+const formatSeason = (data: any): Season => ({
+  title: data.Title,
+  seasonNumber: data.Season,
+  totalSeasons: data.totalSeasons,
+  episodes: data.Episodes,
+});
 
 export const searchByQuery = async (query: string): Promise<Item[]> => {
-  const { data } = await axios.get(`${BASE_URL}&s=${query}`);
+  const { data } = await get({s: query});
   return data.Search as Item[];
 };
 
 export const searchByQueryAndType = async (query: string, type: SearchResultType): Promise<Item[]> => {
-  const { data } = await axios.get(`${BASE_URL}&s=${query}&type=${type}`);
+  const { data } = await get({s: query, type});
   return data.Search as Item[];
 };
 
 export const getItemById = async (id: string): Promise<FullItem> => {
-  const { data } = await axios.get(`${BASE_URL}&i=${id}`);
+  const { data } = await get({i: id});
   return data as FullItem;
 };
 
@@ -44,12 +54,12 @@ export const getItemsByIds = async (ids: string[]): Promise<FullItem[]> => {
 };
 
 export const getSeasonFromTitle = async (title: string, season: number) => {
-  const { data } = await axios.get(`${BASE_URL}&t=${title}&Season=${season}`);
+  const { data } = await get({t: title, Season: season});
   return formatSeason(data);
 };
 
 export const getSeasonFromId = async (id: string, season: number) => {
-  const { data } = await axios.get(`${BASE_URL}&i=${id}&Season=${season}`);
+  const { data } = await get({i: id, Season: season});
   return formatSeason(data);
 };
 
@@ -60,7 +70,7 @@ export const getFullSeriesFromId = async (id: string) => {
 
 export const getFullSeriesFromTitle = async (title: string) => {
   const { totalSeasons, title: seriesTitle } = await getSeasonFromTitle(title, 1);
-  const seasons = await Promise.all(getNumberOfSeasons(sanitizeQuery(seriesTitle), parseInt(totalSeasons, 10)));
+  const seasons = await Promise.all(getNumberOfSeasons(seriesTitle, parseInt(totalSeasons, 10)));
   return {
     title: seriesTitle,
     totalSeasons,

--- a/src/lib/omdbApi.ts
+++ b/src/lib/omdbApi.ts
@@ -1,4 +1,4 @@
-import { RequestParams } from '../types/request';
+import { OmdbRequestParams } from '../types/request';
 import { FullItem, Item, SearchResultType } from '../types/searchResult';
 import { Season, Series } from '../types/series';
 import * as request from './request';
@@ -9,7 +9,7 @@ const API_PARAM = {
   apikey: API_KEY,
 };
 
-const get = (params: RequestParams) => request.get(BASE_URL, { ...API_PARAM, ...params });
+const get = (params: OmdbRequestParams) => request.get(BASE_URL, { ...API_PARAM, ...params });
 
 const getNumberOfSeasons = (title: string, amount: number) => {
   const seasonsPromises = [];

--- a/src/lib/omdbApi.ts
+++ b/src/lib/omdbApi.ts
@@ -1,3 +1,4 @@
+import { RequestParams } from '../types/request';
 import { FullItem, Item, SearchResultType } from '../types/searchResult';
 import { Season, Series } from '../types/series';
 import * as request from './request';
@@ -7,14 +8,6 @@ const BASE_URL = `http://www.omdbapi.com`;
 const API_PARAM = {
   apikey: API_KEY,
 };
-
-interface RequestParams {
-  s?: string;
-  t?: string;
-  type?: SearchResultType;
-  i?: string;
-  Season?: number;
-}
 
 const get = (params: RequestParams) => request.get(BASE_URL, { ...API_PARAM, ...params });
 

--- a/src/lib/request.ts
+++ b/src/lib/request.ts
@@ -1,0 +1,5 @@
+import axios from 'axios';
+import querystringify from 'querystringify';
+
+export const get = (url: string, params: object) =>
+  axios.get(`${url}${querystringify.stringify(params, true)}`);

--- a/src/lib/utils.test.ts
+++ b/src/lib/utils.test.ts
@@ -5,19 +5,6 @@ import { getFullSeriesFromTitle } from './omdbApi';
 import * as utils from './utils';
 
 describe('Utils functions', () => {
-  describe('sanitizeQuery()', () => {
-    it('should be defined', () => {
-      expect(utils.sanitizeQuery).toBeDefined();
-    });
-    it('should sanitize a passed query', () => {
-      const query = 'harry potter';
-      expect(utils.sanitizeQuery(query)).toMatch('harry%20potter');
-    });
-    it('should not sanitize if not needed', () => {
-      const query = 'Interstellar';
-      expect(utils.sanitizeQuery(query)).toMatch(query);
-    });
-  });
   describe('sortColumn()', () => {
     it('should be defined', () => {
       expect(utils.sortByColumn).toBeDefined();

--- a/src/lib/utils.test.ts
+++ b/src/lib/utils.test.ts
@@ -79,7 +79,7 @@ describe('Utils functions', () => {
       expect(seriesAverage.Seasons[1].AverageScore).toEqual(seriesMock.SCORE_S02);
     });
     it('should calculate average score for series taken from API', async () => {
-      const series = await getFullSeriesFromTitle(utils.sanitizeQuery('game of thrones'));
+      const series = await getFullSeriesFromTitle('game of thrones');
       const seriesAverage = utils.calculateSeriesAverageScore(series);
       expect(seriesAverage.Title).toBeDefined();
       expect(seriesAverage.Seasons.length).toBeGreaterThan(1);

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -6,13 +6,6 @@ const NOT_RELEASED = 'N/A';
 export const NOT_RELEASED_TEXT = 'Not yet released';
 
 /**
- * Encode a string as a URI component
- * @param {String} query to encode
- * @returns {String}
- */
-export const sanitizeQuery = (query: string) => encodeURIComponent(query);
-
-/**
  * Get a sorted array of objects sorted by object key value and by asc or desc order
  * @param {Array} items
  * @param {String} column

--- a/src/types/request.ts
+++ b/src/types/request.ts
@@ -1,0 +1,14 @@
+import { SearchResultType } from './searchResult';
+
+type Query = string;
+type Title = string;
+type ImdbId = string;
+type Season = number;
+
+export interface RequestParams {
+  s?: Query;
+  t?: Title;
+  type?: SearchResultType;
+  i?: ImdbId;
+  Season?: Season;
+}

--- a/src/types/request.ts
+++ b/src/types/request.ts
@@ -5,7 +5,7 @@ type Title = string;
 type ImdbId = string;
 type Season = number;
 
-export interface RequestParams {
+export interface OmdbRequestParams {
   s?: Query;
   t?: Title;
   type?: SearchResultType;


### PR DESCRIPTION
This PR seperates omdb api functions from making raw axios requests and decouples api functions from the underlaying request package used.

* Add request file with exported get method that uses axios under the hood.
* Add querystringify package and parse request params only in the request package. This means that it is not up to the request consumer to worry about query parsing.
   * Remove sanitizeQuery since its not needed because of this
